### PR TITLE
Allow to use a "-e ANNOUNCE_IP=a.b.c.d" to use in three servers.

### DIFF
--- a/sentinel/3-alpine/sentinel-entrypoint.sh
+++ b/sentinel/3-alpine/sentinel-entrypoint.sh
@@ -13,6 +13,10 @@ sentinel parallel-syncs docker-cluster 1
 sentinel failover-timeout docker-cluster $SENTINEL_FAILOVER
 EOF
 
+if [ -n "$ANNOUNCE_IP" ]; then
+  echo "sentinel announce-ip $ANNOUNCE_IP" >> /etc/redis/sentinel.conf
+fi
+
 chown redis:redis /etc/redis/sentinel.conf
 
 exec "/usr/local/bin/docker-entrypoint.sh" "$@"

--- a/sentinel/3/sentinel-entrypoint.sh
+++ b/sentinel/3/sentinel-entrypoint.sh
@@ -13,6 +13,10 @@ sentinel parallel-syncs docker-cluster 1
 sentinel failover-timeout docker-cluster $SENTINEL_FAILOVER
 EOF
 
+if [ -n "$ANNOUNCE_IP" ]; then
+  echo "sentinel announce-ip $ANNOUNCE_IP" >> /etc/redis/sentinel.conf
+fi
+
 chown redis:redis /etc/redis/sentinel.conf
 
 exec "/usr/local/bin/docker-entrypoint.sh" "$@"

--- a/sentinel/alpine/sentinel-entrypoint.sh
+++ b/sentinel/alpine/sentinel-entrypoint.sh
@@ -13,6 +13,10 @@ sentinel parallel-syncs docker-cluster 1
 sentinel failover-timeout docker-cluster $SENTINEL_FAILOVER
 EOF
 
+if [ -n "$ANNOUNCE_IP" ]; then
+  echo "sentinel announce-ip $ANNOUNCE_IP" >> /etc/redis/sentinel.conf
+fi
+
 chown redis:redis /etc/redis/sentinel.conf
 
 exec "/usr/local/bin/docker-entrypoint.sh" "$@"

--- a/sentinel/latest/sentinel-entrypoint.sh
+++ b/sentinel/latest/sentinel-entrypoint.sh
@@ -13,6 +13,10 @@ sentinel parallel-syncs docker-cluster 1
 sentinel failover-timeout docker-cluster $SENTINEL_FAILOVER
 EOF
 
+if [ -n "$ANNOUNCE_IP" ]; then
+  echo "sentinel announce-ip $ANNOUNCE_IP" >> /etc/redis/sentinel.conf
+fi
+
 chown redis:redis /etc/redis/sentinel.conf
 
 exec "/usr/local/bin/docker-entrypoint.sh" "$@"


### PR DESCRIPTION
Redis replica commands:

redis-01 (address 10.10.10.1):
```
docker run -it --rm -p 6379:6379 --name redis-01 redis
```
redis-02 (address 10.10.10.2):
```
docker run -it --rm -p 6379:6379 --name redis-02 redis
docker exec -it redis-02 redis-cli slaveof 10.10.10.1 6379
```
redis-03 (address 10.10.10.3):
```
docker run -it --rm -p 6379:6379 --name redis-03 redis
docker exec -it redis-03 redis-cli slaveof 10.10.10.1 6379
```

Sentinel commands:

sentinel-01 (address 10.10.10.1):
```
docker run -it --rm -p 26379:26379 -e SENTINEL_QUORUM=2 -e SENTINEL_DOWN_AFTER=5000 -e SENTINEL_FAILOVER=5000 -e MASTER_HOST=10.10.10.1 -e ANNOUNCE_IP=10.10.10.1 redis-sentinel
```
sentinel-02 (address 10.10.10.2):
```
docker run -it --rm -p 26379:26379 -e SENTINEL_QUORUM=2 -e SENTINEL_DOWN_AFTER=5000 -e SENTINEL_FAILOVER=5000 -e MASTER_HOST=10.10.10.1 -e ANNOUNCE_IP=10.10.10.2 redis-sentinel
```
sentinel-03 (address 10.10.10.3):
```
docker run -it --rm -p 26379:26379 -e SENTINEL_QUORUM=2 -e SENTINEL_DOWN_AFTER=5000 -e SENTINEL_FAILOVER=5000 -e MASTER_HOST=10.10.10.1 -e ANNOUNCE_IP=10.10.10.3 redis-sentinel
```